### PR TITLE
Use absolute links for CSS and JS on 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -30,7 +30,7 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/14
 		padding: 0 !important;
 	}
 </style>
-<link rel='stylesheet' id='wp-block-library-css' href='wp-includes/css/dist/block-library/style.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='wp-block-library-css' href='/wp-includes/css/dist/block-library/style.min.css' type='text/css' media='all' />
 <style id='classic-theme-styles-inline-css' type='text/css'>
 /*! This file is auto-generated */
 .wp-block-button__link{color:#fff;background-color:#32373c;border-radius:9999px;box-shadow:none;text-decoration:none;padding:calc(.667em + 2px) calc(1.333em + 2px);font-size:1.125em}.wp-block-file__button{background:#32373c;color:#fff;text-decoration:none}
@@ -42,19 +42,19 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 :where(.wp-block-columns.is-layout-flex){gap: 2em;}:where(.wp-block-columns.is-layout-grid){gap: 2em;}
 .wp-block-pullquote{font-size: 1.5em;line-height: 1.6;}
 </style>
-<link rel='stylesheet' id='arve-main-css' href='wp-content/plugins/advanced-responsive-video-embedder/build/main.css' type='text/css' media='all' />
-<link rel='stylesheet' id='contact-form-7-css' href='wp-content/plugins/contact-form-7/includes/css/styles.css?ver=5.9.3' type='text/css' media='all' />
-<link rel='stylesheet' id='parent-style-css' href='wp-content/themes/ova-dione/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='arve-main-css' href='/wp-content/plugins/advanced-responsive-video-embedder/build/main.css' type='text/css' media='all' />
+<link rel='stylesheet' id='contact-form-7-css' href='/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=5.9.3' type='text/css' media='all' />
+<link rel='stylesheet' id='parent-style-css' href='/wp-content/themes/ova-dione/style.css' type='text/css' media='all' />
 <link rel='stylesheet' id='ova-dione-fonts-css' href='https://fonts.googleapis.com/css?family=Roboto%3A100%2C200%2C300%2C400%2C500%2C600%2C700%2C800%2C900%22%7CMontserrat%3A100%2C200%2C300%2C400%2C500%2C600%2C700%2C800%2C900&#038;subset=latin%2Clatin-ext' type='text/css' media='all' />
-<link rel='stylesheet' id='bootstrap-css' href='wp-content/themes/ova-dione/assets/css/bootstrap.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='font-awesome-css' href='wp-content/themes/ova-dione/assets/css/font-awesome.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='flickity.min.css-css' href='wp-content/themes/ova-dione/assets/css/flickity.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='magnific-popup.css-css' href='wp-content/themes/ova-dione/assets/css/magnific-popup.css' type='text/css' media='all' />
-<link rel='stylesheet' id='jquery.countdown.css-css' href='wp-content/themes/ova-dione/assets/js/countdown/jquery.countdown.css' type='text/css' media='all' />
-<link rel='stylesheet' id='dione_main.css-css' href='wp-content/themes/ova-dione/assets/css/dione_main.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='ova-dione-default-css' href='wp-content/themes/ova-dione/assets/css/default.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='parent-stylesheet-css' href='wp-content/themes/ova-dione/style.css' type='text/css' media='all' />
-<link rel='stylesheet' id='ova-dione-style-css' href='wp-content/themes/ova-dione-child/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='bootstrap-css' href='/wp-content/themes/ova-dione/assets/css/bootstrap.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='font-awesome-css' href='/wp-content/themes/ova-dione/assets/css/font-awesome.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='flickity.min.css-css' href='/wp-content/themes/ova-dione/assets/css/flickity.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='magnific-popup.css-css' href='/wp-content/themes/ova-dione/assets/css/magnific-popup.css' type='text/css' media='all' />
+<link rel='stylesheet' id='jquery.countdown.css-css' href='/wp-content/themes/ova-dione/assets/js/countdown/jquery.countdown.css' type='text/css' media='all' />
+<link rel='stylesheet' id='dione_main.css-css' href='/wp-content/themes/ova-dione/assets/css/dione_main.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='ova-dione-default-css' href='/wp-content/themes/ova-dione/assets/css/default.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='parent-stylesheet-css' href='/wp-content/themes/ova-dione/style.css' type='text/css' media='all' />
+<link rel='stylesheet' id='ova-dione-style-css' href='/wp-content/themes/ova-dione-child/style.css' type='text/css' media='all' />
 <style id='ova-dione-style-inline-css' type='text/css'>
 
     body{
@@ -239,34 +239,34 @@ body{--wp--preset--color--black: #000000;--wp--preset--color--cyan-bluish-gray: 
 	}
   
 </style>
-<link rel='stylesheet' id='js_composer_front-css' href='wp-content/plugins/js_composer/assets/css/js_composer.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='dione_plugin-css' href='wp-content/plugins/ova-dione/dione-plugin.css' type='text/css' media='all' />
-<script type="text/javascript" src="wp-includes/js/jquery/jquery.min.js" id="jquery-core-js"></script>
-<script type="text/javascript" src="wp-includes/js/jquery/jquery-migrate.min.js" id="jquery-migrate-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/bootstrap.min.js" id="bootstrap-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/pace.min.js" id="pace.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/debouncer.min.js" id="debouncer.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.easing.min.js" id="jquery.easing.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.inview.min.js" id="jquery.inview.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.matchHeight.js" id="jquery.matchHeight.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/isotope.pkgd.min.js" id="isotope.pkgd.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/imagesloaded.pkgd.min.js" id="imagesloaded.pkgd.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/flickity.pkgd.min.js" id="flickity.pkgd.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.countTo.js" id="jquery.countTo.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.magnific-popup.min.js" id="jquery.magnific-popup.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.validate.min.js" id="jquery.validate.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/jquery.flexslider.min.js" id="jquery.flexslider.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/typed.min.js" id="typed.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/countdown/jquery.plugin.js" id="jquery.plugin.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/countdown/jquery.countdown.min.js" id="countdown.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/lib/greensock/TweenMax.min.js" id="TweenMax-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/ScrollMagic.min.js" id="ScrollMagic-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/animation.gsap.min.js" id="animation.gsap.min.js-js"></script>
-<script type="text/javascript" src="wp-content/themes/ova-dione/assets/js/main.js" id="main.js-js"></script>
+<link rel='stylesheet' id='js_composer_front-css' href='/wp-content/plugins/js_composer/assets/css/js_composer.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='dione_plugin-css' href='/wp-content/plugins/ova-dione/dione-plugin.css' type='text/css' media='all' />
+<script type="text/javascript" src="/wp-includes/js/jquery/jquery.min.js" id="jquery-core-js"></script>
+<script type="text/javascript" src="/wp-includes/js/jquery/jquery-migrate.min.js" id="jquery-migrate-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/bootstrap.min.js" id="bootstrap-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/pace.min.js" id="pace.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/debouncer.min.js" id="debouncer.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.easing.min.js" id="jquery.easing.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.inview.min.js" id="jquery.inview.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.matchHeight.js" id="jquery.matchHeight.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/isotope.pkgd.min.js" id="isotope.pkgd.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/imagesloaded.pkgd.min.js" id="imagesloaded.pkgd.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/flickity.pkgd.min.js" id="flickity.pkgd.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.countTo.js" id="jquery.countTo.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.magnific-popup.min.js" id="jquery.magnific-popup.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.validate.min.js" id="jquery.validate.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/jquery.flexslider.min.js" id="jquery.flexslider.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/typed.min.js" id="typed.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/countdown/jquery.plugin.js" id="jquery.plugin.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/countdown/jquery.countdown.min.js" id="countdown.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/lib/greensock/TweenMax.min.js" id="TweenMax-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/ScrollMagic.min.js" id="ScrollMagic-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/animation.gsap.min.js" id="animation.gsap.min.js-js"></script>
+<script type="text/javascript" src="/wp-content/themes/ova-dione/assets/js/main.js" id="main.js-js"></script>
 <style type="text/css">.recentcomments a{display:inline !important;padding:0 !important;margin:0 !important;}</style><meta name="generator" content="Powered by WPBakery Page Builder - drag and drop page builder for WordPress."/>
-<link rel="icon" href="wp-content/uploads/2021/01/cropped-favicon-32x32.png" sizes="32x32" />
-<link rel="icon" href="wp-content/uploads/2021/01/cropped-favicon-192x192.png" sizes="192x192" />
-<link rel="apple-touch-icon" href="wp-content/uploads/2021/01/cropped-favicon-180x180.png" />
+<link rel="icon" href="/wp-content/uploads/2021/01/cropped-favicon-32x32.png" sizes="32x32" />
+<link rel="icon" href="/wp-content/uploads/2021/01/cropped-favicon-192x192.png" sizes="192x192" />
+<link rel="apple-touch-icon" href="/wp-content/uploads/2021/01/cropped-favicon-180x180.png" />
 <meta name="msapplication-TileImage" content="https://summit.dask.org/wp-content/uploads/2021/01/cropped-favicon-270x270.png" />
 		<style type="text/css" id="wp-custom-css">
 			.page:not(.home) nav {
@@ -329,8 +329,8 @@ section#dask {
 
                 <a href="index.html" class="navbar-brand page-scroll font-family-alt letter-spacing-1 text-extra-large text-uppercase">
                 	
-                		<img class="logo-navbar-dark" src="wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-whitetype.png" alt="Dask Distributed Summit">
-                		<img class="logo-navbar-white" src="wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz.png" alt="Dask Distributed Summit"/>
+                		<img class="logo-navbar-dark" src="/wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-whitetype.png" alt="Dask Distributed Summit">
+                		<img class="logo-navbar-white" src="/wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz.png" alt="Dask Distributed Summit"/>
 
                 	                </a>
             </div>
@@ -384,7 +384,7 @@ section#dask {
 
                 <div class="footer-logo xs-text-center">
                     <div id="text-1" class="widget widget_text">			<div class="textwidget"></div>
-		</div><div id="text-2" class="widget widget_text">			<div class="textwidget"><p><img loading="lazy" decoding="async" class="alignnone size-medium wp-image-772" src="wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-300x91.png" alt="" width="300" height="91" srcset="wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-300x91.png 300w, wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-1024x309.png 1024w, wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-768x232.png 768w, wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz.png 1431w" sizes="(max-width: 300px) 100vw, 300px" /></p>
+		</div><div id="text-2" class="widget widget_text">			<div class="textwidget"><p><img loading="lazy" decoding="async" class="alignnone size-medium wp-image-772" src="/wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-300x91.png" alt="" width="300" height="91" srcset="/wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-300x91.png 300w, /wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-1024x309.png 1024w, /wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz-768x232.png 768w, /wp-content/uploads/2021/04/Dask-Distributed-Summit-2021-logo-horiz.png 1431w" sizes="(max-width: 300px) 100vw, 300px" /></p>
 </div>
 		</div>                </div>
         
@@ -417,14 +417,14 @@ section#dask {
 	<a href="index.html#page-top" class="page-scroll scroll-to-top"><i class="fa fa-angle-up"></i></a>
 			</div> <!-- /wrapper -->
 		</div><!-- /container_boxed -->
-		<script type="text/html" id="wpb-modifications"></script><link rel='stylesheet' id='vc_animate-css-css' href='wp-content/plugins/js_composer/assets/lib/bower/animate-css/animate.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='vc_font_awesome_5_shims-css' href='wp-content/plugins/js_composer/assets/lib/bower/font-awesome/css/v4-shims.min.css' type='text/css' media='all' />
-<link rel='stylesheet' id='vc_font_awesome_5-css' href='wp-content/plugins/js_composer/assets/lib/bower/font-awesome/css/all.min.css' type='text/css' media='all' />
-<script type="text/javascript" src="wp-content/plugins/advanced-responsive-video-embedder/build/main.js" id="arve-main-js"></script>
-<script type="text/javascript" src="wp-content/plugins/contact-form-7/includes/swv/js/index.js" id="swv-js"></script>
-<script type="text/javascript" src="wp-content/plugins/contact-form-7/includes/js/index.js" id="contact-form-7-js"></script>
-<script type="text/javascript" src="wp-content/plugins/js_composer/assets/js/dist/js_composer_front.min.js" id="wpb_composer_front_js-js"></script>
-<script type="text/javascript" src="wp-content/plugins/js_composer/assets/lib/vc_waypoints/vc-waypoints.min.js" id="vc_waypoints-js"></script>
+		<script type="text/html" id="wpb-modifications"></script><link rel='stylesheet' id='vc_animate-css-css' href='/wp-content/plugins/js_composer/assets/lib/bower/animate-css/animate.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='vc_font_awesome_5_shims-css' href='/wp-content/plugins/js_composer/assets/lib/bower/font-awesome/css/v4-shims.min.css' type='text/css' media='all' />
+<link rel='stylesheet' id='vc_font_awesome_5-css' href='/wp-content/plugins/js_composer/assets/lib/bower/font-awesome/css/all.min.css' type='text/css' media='all' />
+<script type="text/javascript" src="/wp-content/plugins/advanced-responsive-video-embedder/build/main.js" id="arve-main-js"></script>
+<script type="text/javascript" src="/wp-content/plugins/contact-form-7/includes/swv/js/index.js" id="swv-js"></script>
+<script type="text/javascript" src="/wp-content/plugins/contact-form-7/includes/js/index.js" id="contact-form-7-js"></script>
+<script type="text/javascript" src="/wp-content/plugins/js_composer/assets/js/dist/js_composer_front.min.js" id="wpb_composer_front_js-js"></script>
+<script type="text/javascript" src="/wp-content/plugins/js_composer/assets/lib/vc_waypoints/vc-waypoints.min.js" id="vc_waypoints-js"></script>
 	</body><!-- /body -->
 </html>
 


### PR DESCRIPTION
Use absolute links to include CSS and JavaScript on 404 page template so that it will render properly when missing subpages (e.g. https://summit.dask.org/foo/bar/) are visited.